### PR TITLE
Fix decoder block slicing

### DIFF
--- a/notebooks/en/faiss_with_hf_datasets_and_clip.ipynb
+++ b/notebooks/en/faiss_with_hf_datasets_and_clip.ipynb
@@ -464,7 +464,7 @@
         "\n",
         "\n",
         "# grab the last 5 decoder blocks\n",
-        "blocks = model.transformer.h[-2:]\n",
+        "blocks = model.transformer.h[-5:]\n",
         "\n",
         "# collect all of their MLP parameters\n",
         "target_params = []\n",


### PR DESCRIPTION
## Summary
- fix decoder block selection in CL notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5333db94832992546dcf7ef05cc1